### PR TITLE
ref: move reload problem to the left

### DIFF
--- a/src/lib/components/debugger/GeneralDebuggerComponent.svelte
+++ b/src/lib/components/debugger/GeneralDebuggerComponent.svelte
@@ -113,8 +113,6 @@
 		<DynamicRender component={BarsOutline} props={generalProps} />
 	</button>
 
-	<ResetProblem />
-
 	<button
 		class="btn general-btn"
 		class:invalidOption={!btnUndoActive}
@@ -134,6 +132,8 @@
 	>
 		<DynamicRender component={ReplyOutline} props={reverseProps} />
 	</button>
+
+	<ResetProblem />
 
 	<button class="btn general-btn" title={textCollapse} onclick={toggleExpand}>
 		<DynamicRender


### PR DESCRIPTION
@Pafefo this is a minor change of general btn distribution as I believe <undo, redo, reload> they are quite similar in the what they do. Also if you interact from left to right it is normal that the "reload" option would be the last or one of the last