### PR TITLE
Final fixes

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -65,7 +65,7 @@
 	--cite-bg-color: #cacaca60;
 	--context-max-height: calc(6 * var(--assignment-width));
 	--non-inspecting-opacity: 0.4;
-	--cref-width: 30px /*This variable is adapted to each instance in utils.ts modifyCRef function*/
+	--cref-width: 30px /*This variable is adapted to each instance in utils.ts modifyCRef function*/;
 }
 
 html,

--- a/src/app.css
+++ b/src/app.css
@@ -65,6 +65,7 @@
 	--cite-bg-color: #cacaca60;
 	--context-max-height: calc(6 * var(--assignment-width));
 	--non-inspecting-opacity: 0.4;
+	--cref-width: 30px /*This variable is adapted to each instance in utils.ts modifyCRef function*/
 }
 
 html,

--- a/src/lib/components/AppComponent.svelte
+++ b/src/lib/components/AppComponent.svelte
@@ -164,6 +164,9 @@
 		const decision: Lit = event.decision.toLit();
 		const trailID: number = event.trailID;
 
+		console.log(`decision: ${decision}`);
+		console.log(`trailId: ${trailID}`);
+
 		// This are the decisions that will be reapplied
 		// As solvers are deterministic, reapplying them will lead to the same state.
 		// PSS. It is mandatory to do it before onProblemReset as the the decisions are wiped there.

--- a/src/lib/components/AppComponent.svelte
+++ b/src/lib/components/AppComponent.svelte
@@ -51,7 +51,7 @@
 	} from '$lib/states/trails.svelte.ts';
 	import type { Algorithm } from '$lib/types/algorithm.ts';
 	import type { List, Lit } from '$lib/types/types.ts';
-	import { modifyLiteralWidth } from '$lib/utils.ts';
+	import { modifyCRefWidth, modifyLiteralWidth } from '$lib/utils.ts';
 	import { onMount } from 'svelte';
 	import DebuggerComponent from './debugger/DebuggerComponent.svelte';
 	import { getConfiguredAlgorithm } from './settings/engine/state.svelte.ts';
@@ -135,6 +135,7 @@
 		// We can not keep the breakpoints when the instance is changed
 		clearBreakpoints();
 		modifyLiteralWidth(instance.summary.varCount);
+		modifyCRefWidth(instance.summary.clauseCount);
 		shareReset(instance);
 	}
 
@@ -163,9 +164,6 @@
 		// Get the decisions that will be kept
 		const decision: Lit = event.decision.toLit();
 		const trailID: number = event.trailID;
-
-		console.log(`decision: ${decision}`);
-		console.log(`trailId: ${trailID}`);
 
 		// This are the decisions that will be reapplied
 		// As solvers are deterministic, reapplying them will lead to the same state.

--- a/src/lib/components/StatisticsComponent.svelte
+++ b/src/lib/components/StatisticsComponent.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
 	import type { Trail } from '$lib/entities/Trail.svelte.ts';
-	import { getClausePool } from '$lib/states/problem.svelte.ts';
-	import { getSolverMachine } from '$lib/states/solver-machine.svelte.ts';
 	import {
 		getNoConflicts,
 		getNoDecisions,
@@ -19,9 +17,7 @@
 			return latestTrail.getDL();
 		} else return 0;
 	});
-	const clausesLeft: number = $derived(getClausePool().leftToSatisfy());
 	const visitedClauses: number = $derived(getVisitedClauses());
-	const unsat: boolean = $derived(getSolverMachine().onUnsatState());
 </script>
 
 <statistics>
@@ -41,16 +37,11 @@
 		<span>UPs:</span>
 		<span class="statistic-value">{unitPropagations}</span>
 	</div>
+
 	<div class="metric">
-		Clauses left:
-		<span class="statistic-value">{clausesLeft}</span>
+		Visited Clauses:
+		<span class="statistic-value">{visitedClauses}</span>
 	</div>
-	{#if unsat}
-		<div class="metric">
-			Minimum Clauses:
-			<span class="statistic-value">{visitedClauses}</span>
-		</div>
-	{/if}
 </statistics>
 
 <style>

--- a/src/lib/components/StatisticsComponent.svelte
+++ b/src/lib/components/StatisticsComponent.svelte
@@ -3,13 +3,12 @@
 	import { getClausePool } from '$lib/states/problem.svelte.ts';
 	import { getSolverMachine } from '$lib/states/solver-machine.svelte.ts';
 	import {
-		getClausesLeft,
 		getNoConflicts,
 		getNoDecisions,
 		getNoUnitPropagations,
-		type ClauseCountEntry
+		getVisitedClauses
 	} from '$lib/states/statistics.svelte.ts';
-	import { getLatestTrail, getTrails } from '$lib/states/trails.svelte.ts';
+	import { getLatestTrail } from '$lib/states/trails.svelte.ts';
 
 	const decisions: number = $derived(getNoDecisions());
 	const conflicts: number = $derived(getNoConflicts());
@@ -21,18 +20,7 @@
 		} else return 0;
 	});
 	const clausesLeft: number = $derived(getClausePool().leftToSatisfy());
-	const minimumClausesLeft: number | undefined = $derived.by(() => {
-		const collection: ClauseCountEntry = getClausesLeft();
-		let minimum: number | undefined = undefined;
-		for (let i = 0; i < getTrails().length; i++) {
-			if (
-				(collection[i] !== undefined && minimum === undefined) ||
-				(minimum !== undefined && collection[i] < minimum)
-			)
-				minimum = collection[i];
-		}
-		return minimum;
-	});
+	const visitedClauses: number = $derived(getVisitedClauses());
 	const unsat: boolean = $derived(getSolverMachine().onUnsatState());
 </script>
 
@@ -60,7 +48,7 @@
 	{#if unsat}
 		<div class="metric">
 			Minimum Clauses:
-			<span class="statistic-value">{minimumClausesLeft}</span>
+			<span class="statistic-value">{visitedClauses}</span>
 		</div>
 	{/if}
 </statistics>

--- a/src/lib/components/assignment/ChildlessDecisionComponent.svelte
+++ b/src/lib/components/assignment/ChildlessDecisionComponent.svelte
@@ -29,10 +29,10 @@
 	});
 
 	let chrome: boolean = $derived(onChrome());
-	let isOpen: boolean = $state(false);
+	let openOptions: boolean = $state(false);
 
 	const emitRevert = (): void => {
-		isOpen = !isOpen;
+		openOptions = !openOptions;
 		emitRevertUpToX?.();
 	};
 </script>
@@ -43,18 +43,21 @@
 			class="literal-style decision level-expanded childless {chrome ? 'pad-chrome' : 'pad-others'}"
 			class:previous-assignment={fromPreviousTrail}
 			onclick={() => {
-				isOpen = !isOpen;
+				openOptions = !openOptions;
 			}}
 		>
 			<MathTexComponent equation={assignment.toTeX()} />
 		</button>
-		{#if !fromPreviousTrail}
-			<Dropdown open={isOpen} placement="bottom" class="dropdownClass">
-				<DropdownItem onclick={emitRevert}>Revert up to here</DropdownItem>
-			</Dropdown>
-		{/if}
 	</childless-decision>
 </HeadTailComponent>
+
+{#if !fromPreviousTrail}
+	<Dropdown open={openOptions} class="dropdownClass">
+		<DropdownItem onclick={emitRevert}>
+			<button> Revert up to here </button>
+		</DropdownItem>
+	</Dropdown>
+{/if}
 
 <style>
 	.decision {
@@ -72,9 +75,5 @@
 
 	.previous-assignment {
 		color: color-mix(in srgb, var(--decision-color) 60%, transparent);
-	}
-
-	:global(.dropdownClass) {
-		overflow: visible;
 	}
 </style>

--- a/src/lib/components/tools/OccurrenceListComponent.svelte
+++ b/src/lib/components/tools/OccurrenceListComponent.svelte
@@ -235,8 +235,8 @@
 	}
 
 	.enumerate {
-		width: var(--assignment-width);
-		height: var(--assignment-width);
+		width: var(--cref-width);
+		height: var(--cref-width);
 		display: flex;
 		justify-content: center;
 		align-items: center;

--- a/src/lib/components/tools/OccurrenceListComponent.svelte
+++ b/src/lib/components/tools/OccurrenceListComponent.svelte
@@ -231,7 +231,7 @@
 		flex-direction: row;
 		align-items: center;
 		gap: 0.5rem;
-		padding: 0.2rem 0.4rem;
+		padding: 0rem 0.4rem;
 	}
 
 	.enumerate {

--- a/src/lib/components/tools/OccurrenceListComponent.svelte
+++ b/src/lib/components/tools/OccurrenceListComponent.svelte
@@ -35,20 +35,12 @@
 
 	const using2Watch: boolean = $derived(getSolverMachine().identify() === 'twatch');
 
-	function followActive(node: HTMLElement, isActive: boolean) {
-		// This first condition is needed to update the pointer when the view is created
-		if (isActive) {
-			node.scrollIntoView({ behavior: 'smooth', block: 'center' });
-		}
-		// This is where the reactivity happen
-		return {
-			//This is called by svelte when the value that was passed changes (in this case, the is active)
-			update(newIsActive: boolean) {
-				if (newIsActive) {
-					node.scrollIntoView({ behavior: 'smooth', block: 'center' });
-				}
+	function followActive(node: HTMLElement, isActive: () => boolean) {
+		$effect(() => {
+			if (isActive()) {
+				node.scrollIntoView({ behavior: 'smooth', block: 'center' });
 			}
-		};
+		});
 	}
 
 	let clauses: Maybe<Clause>[] = $derived.by(() => {
@@ -143,12 +135,12 @@
 </script>
 
 <division class:invisible={!using2Watch}
-	>Watched clauses <span class:invisible={clauses.length - 1 <= 0}>({clauses.length - 1})</span
+	>Watched clauses <span class:invisible={clauses.length - 1 <= 0}>: {clauses.length - 1}</span
 	></division
 >
 <occurrence-list class:main-list={using2Watch}>
 	{#each clauses as maybeClause, i (i)}
-		<div class="occurrence-list-item" use:followActive={inspectingClause(maybeClause)}>
+		<div class="occurrence-list-item" use:followActive={() => inspectingClause(maybeClause)}>
 			<HeadTailComponent display={inspectingClause(maybeClause)} verticalList={true}>
 				<div class="enumerate" class:inspecting={inspectingClause(maybeClause)}>
 					{#if isJust(maybeClause)}
@@ -177,7 +169,7 @@
 
 <division class:invisible={!using2Watch}
 	>Non watched clauses <span class:invisible={nonWatchedClauses.length === 0}
-		>({nonWatchedClauses.length})</span
+		>: {nonWatchedClauses.length}</span
 	></division
 >
 {#if using2Watch}

--- a/src/lib/entities/ClausePool.svelte.ts
+++ b/src/lib/entities/ClausePool.svelte.ts
@@ -85,15 +85,6 @@ class ClausePool implements IClausePool {
 		return p ? [...this.clauses.values()].filter(p) : [...this.clauses.values()];
 	}
 
-	leftToSatisfy(): number {
-		let leftToSatisfy: number = 0;
-		this.clauses.forEach((clause) => {
-			const evaluation: ClauseEval = clause.eval();
-			if (!isSatisfiedEval(evaluation)) leftToSatisfy += 1;
-		});
-		return leftToSatisfy;
-	}
-
 	size(): number {
 		return this.clauses.size;
 	}

--- a/src/lib/entities/WatchTable.svelte.ts
+++ b/src/lib/entities/WatchTable.svelte.ts
@@ -84,11 +84,7 @@ export default class WatchTable {
 
 	addWatches(clause: Clause): void {
 		// The invariant is that the watches appears on the very first two literals of the clause
-		if (clause.isTemporal()) {
-			logWarning('Add watches', 'Skipping temporal clause when adding watches');
-		} else if (clause.size() < 2) {
-			logWarning('Add watches', 'Skipping unit or empty clause when adding watches');
-		} else {
+		if (!clause.isTemporal() && clause.size() >= 2) {
 			const literals: Literal[] = clause.getLiterals();
 			const cRef = clause.getCRef();
 			// Watch the first two literals in the clause

--- a/src/lib/solvers/backtracking/bkt-domain.svelte.ts
+++ b/src/lib/solvers/backtracking/bkt-domain.svelte.ts
@@ -1,13 +1,13 @@
-import Clause, { isUnsatisfiedEval, type ClauseEval } from '$lib/entities/Clause.svelte.ts';
+import Clause from '$lib/entities/Clause.svelte.ts';
 import type ClausePool from '$lib/entities/ClausePool.svelte.ts';
 import { type VisitingOccurrenceList } from '$lib/entities/OccurrenceList.svelte.ts';
 import type { VariablePool } from '$lib/entities/VariablePool.svelte.ts';
 import {
 	atLevelZero,
 	getNextClause,
+	isClauseFalsified,
 	allAssigned as solverAllAssigned,
 	backtracking as solverBacktracking,
-	clauseEvaluation as solverClauseEvaluation,
 	complementaryOccurrences as solverComplementaryOccurrences,
 	decide as solverDecide
 } from '$lib/solvers/shared.svelte.ts';
@@ -117,9 +117,7 @@ export const nextClause: BKT_NEXT_OCCURRENCE_FUN = () => {
 export type BKT_CONFLICT_DETECTION_FUN = (cRef: CRef) => boolean;
 
 export const unsatisfiedClause: BKT_CONFLICT_DETECTION_FUN = (cRef: CRef) => {
-	const pool: ClausePool = getClausePool();
-	const evaluation: ClauseEval = solverClauseEvaluation(pool, cRef);
-	return isUnsatisfiedEval(evaluation);
+	return isClauseFalsified(cRef);
 };
 
 export type BKT_AT_LEVEL_ZERO_FUN = () => boolean;

--- a/src/lib/solvers/backtracking/bkt-domain.svelte.ts
+++ b/src/lib/solvers/backtracking/bkt-domain.svelte.ts
@@ -1,13 +1,12 @@
 import Clause, { isUnsatisfiedEval, type ClauseEval } from '$lib/entities/Clause.svelte.ts';
 import type ClausePool from '$lib/entities/ClausePool.svelte.ts';
 import {
-	type OccurrenceList,
-	type PreprocessingList,
 	type VisitingOccurrenceList
 } from '$lib/entities/OccurrenceList.svelte.ts';
 import type { VariablePool } from '$lib/entities/VariablePool.svelte.ts';
 import {
 	atLevelZero,
+	getNextClause,
 	allAssigned as solverAllAssigned,
 	backtracking as solverBacktracking,
 	clauseEvaluation as solverClauseEvaluation,
@@ -16,12 +15,10 @@ import {
 } from '$lib/solvers/shared.svelte.ts';
 import {
 	getClausePool,
-	getCurrentOccurrences,
 	getOccurrenceListQueue,
 	getOccurrencesTableMapping,
 	getVariablePool
 } from '$lib/states/problem.svelte.ts';
-import { logFatal } from '$lib/states/toasts.svelte.ts';
 import { unwrapEither } from '$lib/types/either.ts';
 import type { CRef, Lit } from '$lib/types/types.ts';
 
@@ -116,14 +113,7 @@ export const traversedOccurrenceList: BKT_TRAVERSED_OCCURRENCE_LIST_FUN = (
 export type BKT_NEXT_OCCURRENCE_FUN = () => CRef;
 
 export const nextClause: BKT_NEXT_OCCURRENCE_FUN = () => {
-	const visitingOccurrences: VisitingOccurrenceList = getCurrentOccurrences();
-	const unwrappedOccurrences: NonNullable<PreprocessingList | OccurrenceList> =
-		unwrapEither(visitingOccurrences);
-	if (!unwrappedOccurrences.isEmpty()) {
-		logFatal('The occurrence list is empty');
-	} else {
-		return unwrappedOccurrences.next();
-	}
+	return getNextClause();
 };
 
 export type BKT_CONFLICT_DETECTION_FUN = (cRef: CRef) => boolean;

--- a/src/lib/solvers/backtracking/bkt-domain.svelte.ts
+++ b/src/lib/solvers/backtracking/bkt-domain.svelte.ts
@@ -1,8 +1,6 @@
 import Clause, { isUnsatisfiedEval, type ClauseEval } from '$lib/entities/Clause.svelte.ts';
 import type ClausePool from '$lib/entities/ClausePool.svelte.ts';
-import {
-	type VisitingOccurrenceList
-} from '$lib/entities/OccurrenceList.svelte.ts';
+import { type VisitingOccurrenceList } from '$lib/entities/OccurrenceList.svelte.ts';
 import type { VariablePool } from '$lib/entities/VariablePool.svelte.ts';
 import {
 	atLevelZero,

--- a/src/lib/solvers/cdcl/cdcl-domain.svelte.ts
+++ b/src/lib/solvers/cdcl/cdcl-domain.svelte.ts
@@ -7,8 +7,6 @@ import Clause, {
 import type ClausePool from '$lib/entities/ClausePool.svelte.ts';
 import { ConflictAnalysis, type VirtualResolution } from '$lib/entities/ConflictAnalysis.svelte.ts';
 import {
-	type OccurrenceList,
-	type PreprocessingList,
 	type VisitingOccurrenceList
 } from '$lib/entities/OccurrenceList.svelte.ts';
 import type { Trail } from '$lib/entities/Trail.svelte.ts';
@@ -17,6 +15,7 @@ import type { VariablePool } from '$lib/entities/VariablePool.svelte.ts';
 import {
 	atLevelZero,
 	clauseEvaluation,
+	getNextClause,
 	allAssigned as solverAllAssigned,
 	complementaryOccurrences as solverComplementaryOccurrences,
 	decide as solverDecide,
@@ -26,7 +25,6 @@ import {
 import { getConflictAnalysis, setConflictAnalysis } from '$lib/states/conflict-anlysis.svelte.ts';
 import {
 	getClausePool,
-	getCurrentOccurrences,
 	getOccurrenceListQueue,
 	getOccurrencesTableMapping,
 	getProblemStore,
@@ -167,14 +165,7 @@ export const traversedOccurrenceList: CDCL_TRAVERSED_OCCURRENCE_LIST_FUN = (
 export type CDCL_NEXT_OCCURRENCE_FUN = () => CRef;
 
 export const nextClause: CDCL_NEXT_OCCURRENCE_FUN = () => {
-	const visitingOccurrences: VisitingOccurrenceList = getCurrentOccurrences();
-	const unwrappedOccurrences: NonNullable<PreprocessingList | OccurrenceList> =
-		unwrapEither(visitingOccurrences);
-	if (unwrappedOccurrences.isEmpty()) {
-		logFatal('The occurrence list is empty');
-	} else {
-		return unwrappedOccurrences.next();
-	}
+	return getNextClause();
 };
 
 export type CDCL_CONFLICT_DETECTION_FUN = (cRef: CRef) => boolean;

--- a/src/lib/solvers/cdcl/cdcl-domain.svelte.ts
+++ b/src/lib/solvers/cdcl/cdcl-domain.svelte.ts
@@ -6,9 +6,7 @@ import Clause, {
 } from '$lib/entities/Clause.svelte.ts';
 import type ClausePool from '$lib/entities/ClausePool.svelte.ts';
 import { ConflictAnalysis, type VirtualResolution } from '$lib/entities/ConflictAnalysis.svelte.ts';
-import {
-	type VisitingOccurrenceList
-} from '$lib/entities/OccurrenceList.svelte.ts';
+import { type VisitingOccurrenceList } from '$lib/entities/OccurrenceList.svelte.ts';
 import type { Trail } from '$lib/entities/Trail.svelte.ts';
 import type VariableAssignment from '$lib/entities/VariableAssignment.ts';
 import type { VariablePool } from '$lib/entities/VariablePool.svelte.ts';

--- a/src/lib/solvers/cdcl/cdcl-domain.svelte.ts
+++ b/src/lib/solvers/cdcl/cdcl-domain.svelte.ts
@@ -1,7 +1,6 @@
 import { backjumping as backjumpingAlg } from '$lib/algorithms/backjumping.ts';
 import Clause, {
 	isUnitEval,
-	isUnsatisfiedEval,
 	type ClauseEval
 } from '$lib/entities/Clause.svelte.ts';
 import type ClausePool from '$lib/entities/ClausePool.svelte.ts';
@@ -14,6 +13,7 @@ import {
 	atLevelZero,
 	clauseEvaluation,
 	getNextClause,
+	isClauseFalsified,
 	allAssigned as solverAllAssigned,
 	complementaryOccurrences as solverComplementaryOccurrences,
 	decide as solverDecide,
@@ -169,9 +169,7 @@ export const nextClause: CDCL_NEXT_OCCURRENCE_FUN = () => {
 export type CDCL_CONFLICT_DETECTION_FUN = (cRef: CRef) => boolean;
 
 export const unsatisfiedClause: CDCL_CONFLICT_DETECTION_FUN = (cRef: CRef) => {
-	const pool: ClausePool = getClausePool();
-	const evaluation: ClauseEval = clauseEvaluation(pool, cRef);
-	return isUnsatisfiedEval(evaluation);
+	return isClauseFalsified(cRef);
 };
 
 export type CDCL_CHECK_PENDING_OCCURRENCE_LISTS_FUN = () => boolean;

--- a/src/lib/solvers/cdcl/cdcl-domain.svelte.ts
+++ b/src/lib/solvers/cdcl/cdcl-domain.svelte.ts
@@ -1,8 +1,5 @@
 import { backjumping as backjumpingAlg } from '$lib/algorithms/backjumping.ts';
-import Clause, {
-	isUnitEval,
-	type ClauseEval
-} from '$lib/entities/Clause.svelte.ts';
+import Clause, { isUnitEval, type ClauseEval } from '$lib/entities/Clause.svelte.ts';
 import type ClausePool from '$lib/entities/ClausePool.svelte.ts';
 import { ConflictAnalysis, type VirtualResolution } from '$lib/entities/ConflictAnalysis.svelte.ts';
 import { type VisitingOccurrenceList } from '$lib/entities/OccurrenceList.svelte.ts';

--- a/src/lib/solvers/cdcl/cdcl-solver-transitions.svelte.ts
+++ b/src/lib/solvers/cdcl/cdcl-solver-transitions.svelte.ts
@@ -9,6 +9,7 @@ import type { Trail } from '$lib/entities/Trail.svelte.ts';
 import {
 	conflictAnalysisFinishedEventBus,
 	conflictDetectedEventBus,
+	newTrailStackedEventBus,
 	visitingComplementaryOccEventBus
 } from '$lib/events/events.ts';
 import { getConflictAnalysis } from '$lib/states/conflict-anlysis.svelte.ts';
@@ -125,6 +126,9 @@ export const conflictAnalysisBlock = (): void => {
 
 		// Push the new trail after backjumping and notify
 		pushTrailTransition(trailAfterBJ);
+
+		// Notify a new trail was pushed
+		newTrailStackedEventBus.emit();
 
 		const propagated: Lit = unitPropagationTransition(cRef, 'backjumping');
 		const occurrenceList: VisitingOccurrenceList =

--- a/src/lib/solvers/dpll/dpll-domain.svelte.ts
+++ b/src/lib/solvers/dpll/dpll-domain.svelte.ts
@@ -1,8 +1,6 @@
 import { isUnitEval, isUnsatisfiedEval, type ClauseEval } from '$lib/entities/Clause.svelte.ts';
 import type ClausePool from '$lib/entities/ClausePool.svelte.ts';
-import {
-	type VisitingOccurrenceList
-} from '$lib/entities/OccurrenceList.svelte.ts';
+import { type VisitingOccurrenceList } from '$lib/entities/OccurrenceList.svelte.ts';
 import type { VariablePool } from '$lib/entities/VariablePool.svelte.ts';
 import {
 	atLevelZero,

--- a/src/lib/solvers/dpll/dpll-domain.svelte.ts
+++ b/src/lib/solvers/dpll/dpll-domain.svelte.ts
@@ -1,14 +1,13 @@
 import { isUnitEval, isUnsatisfiedEval, type ClauseEval } from '$lib/entities/Clause.svelte.ts';
 import type ClausePool from '$lib/entities/ClausePool.svelte.ts';
 import {
-	type OccurrenceList,
-	type PreprocessingList,
 	type VisitingOccurrenceList
 } from '$lib/entities/OccurrenceList.svelte.ts';
 import type { VariablePool } from '$lib/entities/VariablePool.svelte.ts';
 import {
 	atLevelZero,
 	clauseEvaluation,
+	getNextClause,
 	allAssigned as solverAllAssigned,
 	backtracking as solverBacktracking,
 	complementaryOccurrences as solverComplementaryOccurrences,
@@ -18,13 +17,11 @@ import {
 } from '$lib/solvers/shared.svelte.ts';
 import {
 	getClausePool,
-	getCurrentOccurrences,
 	getOccurrenceListQueue,
 	getOccurrencesTableMapping,
 	getVariablePool,
 	wipeOccurrences
 } from '$lib/states/problem.svelte.ts';
-import { logFatal } from '$lib/states/toasts.svelte.ts';
 import { unwrapEither } from '$lib/types/either.ts';
 import type { CRef, Lit } from '$lib/types/types.ts';
 
@@ -134,14 +131,7 @@ export const traversedOccurrenceList: DPLL_TRAVERSED_OCCURRENCE_LIST_FUN = (
 export type DPLL_NEXT_OCCURRENCE_FUN = () => CRef;
 
 export const nextClause: DPLL_NEXT_OCCURRENCE_FUN = () => {
-	const visitingOccurrences: VisitingOccurrenceList = getCurrentOccurrences();
-	const unwrappedOccurrences: NonNullable<PreprocessingList | OccurrenceList> =
-		unwrapEither(visitingOccurrences);
-	if (unwrappedOccurrences.isEmpty()) {
-		logFatal('The occurrence list is empty');
-	} else {
-		return unwrappedOccurrences.next();
-	}
+	return getNextClause();
 };
 
 export type DPLL_CONFLICT_DETECTION_FUN = (cRef: CRef) => boolean;

--- a/src/lib/solvers/dpll/dpll-domain.svelte.ts
+++ b/src/lib/solvers/dpll/dpll-domain.svelte.ts
@@ -1,4 +1,4 @@
-import { isUnitEval, isUnsatisfiedEval, type ClauseEval } from '$lib/entities/Clause.svelte.ts';
+import { isUnitEval, type ClauseEval } from '$lib/entities/Clause.svelte.ts';
 import type ClausePool from '$lib/entities/ClausePool.svelte.ts';
 import { type VisitingOccurrenceList } from '$lib/entities/OccurrenceList.svelte.ts';
 import type { VariablePool } from '$lib/entities/VariablePool.svelte.ts';
@@ -6,6 +6,7 @@ import {
 	atLevelZero,
 	clauseEvaluation,
 	getNextClause,
+	isClauseFalsified,
 	allAssigned as solverAllAssigned,
 	backtracking as solverBacktracking,
 	complementaryOccurrences as solverComplementaryOccurrences,
@@ -135,9 +136,7 @@ export const nextClause: DPLL_NEXT_OCCURRENCE_FUN = () => {
 export type DPLL_CONFLICT_DETECTION_FUN = (cRef: CRef) => boolean;
 
 export const unsatisfiedClause: DPLL_CONFLICT_DETECTION_FUN = (cRef: CRef) => {
-	const pool: ClausePool = getClausePool();
-	const evaluation: ClauseEval = clauseEvaluation(pool, cRef);
-	return isUnsatisfiedEval(evaluation);
+	return isClauseFalsified(cRef);
 };
 
 export type DPLL_CHECK_PENDING_OCCURRENCE_LISTS_FUN = () => boolean;

--- a/src/lib/solvers/shared.svelte.ts
+++ b/src/lib/solvers/shared.svelte.ts
@@ -2,6 +2,11 @@ import type Clause from '$lib/entities/Clause.svelte.ts';
 import type { ClauseEval } from '$lib/entities/Clause.svelte.ts';
 import type ClausePool from '$lib/entities/ClausePool.svelte.ts';
 import Literal from '$lib/entities/Literal.svelte.ts';
+import type {
+	OccurrenceList,
+	PreprocessingList,
+	VisitingOccurrenceList
+} from '$lib/entities/OccurrenceList.svelte.ts';
 import type { EWC } from '$lib/entities/Problem.svelte.ts';
 import { Trail } from '$lib/entities/Trail.svelte.ts';
 import type Variable from '$lib/entities/Variable.svelte.ts';
@@ -11,12 +16,16 @@ import type { VariablePool } from '$lib/entities/VariablePool.svelte.ts';
 import { decisionMadeEventBus, newTrailStackedEventBus } from '$lib/events/events.ts';
 import { getAssignment, type AssignmentEvent } from '$lib/states/assignment.svelte.ts';
 import { isBreakpoint } from '$lib/states/breakpoints.svelte.ts';
-import { getVariablePool } from '$lib/states/problem.svelte.ts';
+import { getCurrentOccurrences, getVariablePool } from '$lib/states/problem.svelte.ts';
 import { getSolverMachine } from '$lib/states/solver-machine.svelte.ts';
-import { increaseNoConflicts, increaseNoUnitPropagations } from '$lib/states/statistics.svelte.ts';
+import {
+	increaseNoConflicts,
+	increaseNoUnitPropagations,
+	increaseNoVisitedClauses
+} from '$lib/states/statistics.svelte.ts';
 import { logBreakpoint, logFatal } from '$lib/states/toasts.svelte.ts';
 import { getLatestTrail, stackTrail } from '$lib/states/trails.svelte.ts';
-import { fromLeft, fromRight, isLeft } from '$lib/types/either.ts';
+import { fromLeft, fromRight, isLeft, unwrapEither } from '$lib/types/either.ts';
 import type { CRef, Lit, Var } from '$lib/types/types.ts';
 import { fromJust, isJust, type Maybe } from '../types/maybe.ts';
 
@@ -221,4 +230,15 @@ export const finalStateControl = (): void => {
 
 export const obtainCRefFromEWC = (watch: EWC): CRef => {
 	return isLeft(watch) ? fromLeft(watch).cRef : fromRight(watch);
+};
+
+export const getNextClause: () => CRef = () => {
+	const visitingOccurrences: VisitingOccurrenceList = getCurrentOccurrences();
+	const unwrappedOccurrences: NonNullable<PreprocessingList | OccurrenceList> =
+		unwrapEither(visitingOccurrences);
+	if (unwrappedOccurrences.isEmpty()) {
+		logFatal('The occurrence list is empty');
+	}
+	increaseNoVisitedClauses();
+	return unwrappedOccurrences.next();
 };

--- a/src/lib/solvers/shared.svelte.ts
+++ b/src/lib/solvers/shared.svelte.ts
@@ -1,5 +1,5 @@
 import type Clause from '$lib/entities/Clause.svelte.ts';
-import type { ClauseEval } from '$lib/entities/Clause.svelte.ts';
+import { isUnsatisfiedEval, type ClauseEval } from '$lib/entities/Clause.svelte.ts';
 import type ClausePool from '$lib/entities/ClausePool.svelte.ts';
 import Literal from '$lib/entities/Literal.svelte.ts';
 import type {
@@ -16,7 +16,11 @@ import type { VariablePool } from '$lib/entities/VariablePool.svelte.ts';
 import { decisionMadeEventBus, newTrailStackedEventBus } from '$lib/events/events.ts';
 import { getAssignment, type AssignmentEvent } from '$lib/states/assignment.svelte.ts';
 import { isBreakpoint } from '$lib/states/breakpoints.svelte.ts';
-import { getCurrentOccurrences, getVariablePool } from '$lib/states/problem.svelte.ts';
+import {
+	getClausePool,
+	getCurrentOccurrences,
+	getVariablePool
+} from '$lib/states/problem.svelte.ts';
 import { getSolverMachine } from '$lib/states/solver-machine.svelte.ts';
 import {
 	increaseNoConflicts,
@@ -241,4 +245,10 @@ export const getNextClause: () => CRef = () => {
 	}
 	increaseNoVisitedClauses();
 	return unwrappedOccurrences.next();
+};
+
+export const isClauseFalsified = (cRef: CRef): boolean => {
+	const pool: ClausePool = getClausePool();
+	const evaluation: ClauseEval = clauseEvaluation(pool, cRef);
+	return isUnsatisfiedEval(evaluation);
 };

--- a/src/lib/solvers/shared.svelte.ts
+++ b/src/lib/solvers/shared.svelte.ts
@@ -13,13 +13,9 @@ import { getAssignment, type AssignmentEvent } from '$lib/states/assignment.svel
 import { isBreakpoint } from '$lib/states/breakpoints.svelte.ts';
 import { getVariablePool } from '$lib/states/problem.svelte.ts';
 import { getSolverMachine } from '$lib/states/solver-machine.svelte.ts';
-import {
-	increaseNoConflicts,
-	increaseNoUnitPropagations,
-	updateClausesLeft
-} from '$lib/states/statistics.svelte.ts';
+import { increaseNoConflicts, increaseNoUnitPropagations } from '$lib/states/statistics.svelte.ts';
 import { logBreakpoint, logFatal } from '$lib/states/toasts.svelte.ts';
-import { getLatestTrail, getTrails, stackTrail } from '$lib/states/trails.svelte.ts';
+import { getLatestTrail, stackTrail } from '$lib/states/trails.svelte.ts';
 import { fromLeft, fromRight, isLeft } from '$lib/types/either.ts';
 import type { CRef, Lit, Var } from '$lib/types/types.ts';
 import { fromJust, isJust, type Maybe } from '../types/maybe.ts';
@@ -128,7 +124,6 @@ export const atLevelZero = (): boolean => {
 const doAssignment = (varId: Var, assignment: Assignment): void => {
 	// Notice that assignment \in { true, false, undefined }
 	getVariablePool().assign(varId, assignment);
-	updateClausesLeft(getTrails().length);
 	if (assignment !== undefined) {
 		// i.e., assignment is either true or false
 		// Here assignment is inverted as when creating the literal the second parameter indicates if it has hat or not

--- a/src/lib/solvers/twatch/twatch-domain.svelte.ts
+++ b/src/lib/solvers/twatch/twatch-domain.svelte.ts
@@ -31,6 +31,7 @@ import {
 	getWatchTableMapping,
 	wipeOccurrences
 } from '$lib/states/problem.svelte.ts';
+import { increaseNoVisitedClauses } from '$lib/states/statistics.svelte.ts';
 import { logFatal } from '$lib/states/toasts.svelte.ts';
 import { getLatestTrail, stackTrail } from '$lib/states/trails.svelte.ts';
 import {
@@ -233,6 +234,7 @@ export const nextClause: TWATCH_NEXT_OCCURRENCE_FUN = () => {
 	if (unwrapEither(visitingWatches).isEmpty()) {
 		logFatal('The watch list is empty');
 	}
+	increaseNoVisitedClauses();
 	return isRight(visitingWatches)
 		? makeLeft(fromRight(visitingWatches).next())
 		: makeRight(fromLeft(visitingWatches).next());

--- a/src/lib/solvers/twatch/twatch-solver-transitions.svelte.ts
+++ b/src/lib/solvers/twatch/twatch-solver-transitions.svelte.ts
@@ -14,6 +14,7 @@ import type { Watch } from '$lib/entities/WatchTable.svelte.ts';
 import {
 	conflictAnalysisFinishedEventBus,
 	conflictDetectedEventBus,
+	newTrailStackedEventBus,
 	visitingComplementaryOccEventBus
 } from '$lib/events/events.ts';
 import { getConflictAnalysis } from '$lib/states/conflict-anlysis.svelte.ts';
@@ -160,6 +161,9 @@ export const conflictAnalysisBlock = (): void => {
 
 		// Push the new trail after backjumping and notify
 		pushTrailTransition(trailAfterBJ);
+
+		// Now, we have no notify that a new trail was pushed
+		newTrailStackedEventBus.emit();
 
 		const propagated: Lit = unitPropagationTransition(cRef, 'backjumping');
 		queuesUpdateBlock(propagated);

--- a/src/lib/states/statistics.svelte.ts
+++ b/src/lib/states/statistics.svelte.ts
@@ -1,20 +1,7 @@
-import { getClausePool } from './problem.svelte.ts';
-
-export interface ClauseCountEntry {
-	[key: number]: number;
-}
-
-export interface Statistics {
-	noDecisions: number;
-	noConflicts: number;
-	noUnitPropagations: number;
-	clausesLeft: ClauseCountEntry;
-}
-
 let noDecisions: number = $state(0);
 let noConflicts: number = $state(0);
 let noUnitPropagations: number = $state(0);
-let clausesLeft: ClauseCountEntry = $state({});
+let visitedClauses: number = $state(0);
 
 export const increaseNoDecisions = (): void => {
 	noDecisions += 1;
@@ -40,34 +27,14 @@ export const decreaseNoUnitPropagations = (): void => {
 	noUnitPropagations -= 1;
 };
 
-export const updateClausesLeft = (nTrail: number): void => {
-	const nClauses: number = getClausePool().leftToSatisfy();
-	clausesLeft[nTrail] = nClauses;
-};
-
-export const updateStatistics = (newStatistics: Statistics): void => {
-	noDecisions = newStatistics.noDecisions;
-	noConflicts = newStatistics.noConflicts;
-	noUnitPropagations = newStatistics.noUnitPropagations;
-	clausesLeft = newStatistics.clausesLeft;
-};
-
 export const resetStatistics = (): void => {
 	noDecisions = 0;
 	noConflicts = 0;
 	noUnitPropagations = 0;
-	clausesLeft = {};
+	visitedClauses = 0;
 };
 
-export const getStatistics = () => {
-	return {
-		noDecisions: noDecisions,
-		noConflicts: noConflicts,
-		noUnitPropagations: noUnitPropagations,
-		clausesLeft: clausesLeft
-	} as Statistics;
-};
 export const getNoDecisions = () => noDecisions;
 export const getNoConflicts = () => noConflicts;
 export const getNoUnitPropagations = () => noUnitPropagations;
-export const getClausesLeft = () => clausesLeft;
+export const getVisitedClauses = () => visitedClauses;

--- a/src/lib/states/statistics.svelte.ts
+++ b/src/lib/states/statistics.svelte.ts
@@ -1,40 +1,32 @@
 let noDecisions: number = $state(0);
 let noConflicts: number = $state(0);
 let noUnitPropagations: number = $state(0);
-let visitedClauses: number = $state(0);
+let noVisitedClauses: number = $state(0);
 
 export const increaseNoDecisions = (): void => {
 	noDecisions += 1;
-};
-
-export const decreaseNoDecision = (): void => {
-	noDecisions -= 1;
 };
 
 export const increaseNoConflicts = (): void => {
 	noConflicts += 1;
 };
 
-export const decreaseNoConflicts = (): void => {
-	noConflicts -= 1;
-};
-
 export const increaseNoUnitPropagations = (): void => {
 	noUnitPropagations += 1;
 };
 
-export const decreaseNoUnitPropagations = (): void => {
-	noUnitPropagations -= 1;
+export const increaseNoVisitedClauses = (): void => {
+	noVisitedClauses += 1;
 };
 
 export const resetStatistics = (): void => {
 	noDecisions = 0;
 	noConflicts = 0;
 	noUnitPropagations = 0;
-	visitedClauses = 0;
+	noVisitedClauses = 0;
 };
 
 export const getNoDecisions = () => noDecisions;
 export const getNoConflicts = () => noConflicts;
 export const getNoUnitPropagations = () => noUnitPropagations;
-export const getVisitedClauses = () => visitedClauses;
+export const getVisitedClauses = () => noVisitedClauses;

--- a/src/lib/states/trail-decisions.svelte.ts
+++ b/src/lib/states/trail-decisions.svelte.ts
@@ -34,6 +34,7 @@ export function saveDecision(decision: Lit): void {
 		logError('Decision store', 'Missing last decisions list');
 	}
 	trailDecisions[trailDecisions.length - 1].decisions.push({ decision });
+	console.log(trailDecisions);
 }
 
 export function allocDecisionsTrail(): void {
@@ -43,6 +44,7 @@ export function allocDecisionsTrail(): void {
 export function retrieveEarlierDecisions(trailID: number, decision: Lit): List<SavedDecision> {
 	// This function retrieves the earlier decisions up to the given trailID,
 	// including the decisions made at trailID up to (but not including) the given decision.
+	console.log(trailDecisions);
 
 	if (trailID < 0 || trailID >= trailDecisions.length) {
 		logFatal(

--- a/src/lib/states/trail-decisions.svelte.ts
+++ b/src/lib/states/trail-decisions.svelte.ts
@@ -34,7 +34,6 @@ export function saveDecision(decision: Lit): void {
 		logError('Decision store', 'Missing last decisions list');
 	}
 	trailDecisions[trailDecisions.length - 1].decisions.push({ decision });
-	console.log(trailDecisions);
 }
 
 export function allocDecisionsTrail(): void {
@@ -44,7 +43,6 @@ export function allocDecisionsTrail(): void {
 export function retrieveEarlierDecisions(trailID: number, decision: Lit): List<SavedDecision> {
 	// This function retrieves the earlier decisions up to the given trailID,
 	// including the decisions made at trailID up to (but not including) the given decision.
-	console.log(trailDecisions);
 
 	if (trailID < 0 || trailID >= trailDecisions.length) {
 		logFatal(

--- a/src/lib/states/trails.svelte.ts
+++ b/src/lib/states/trails.svelte.ts
@@ -1,6 +1,5 @@
 import type Clause from '$lib/entities/Clause.svelte.ts';
 import { Trail } from '$lib/entities/Trail.svelte.ts';
-import { newTrailStackedEventBus } from '$lib/events/events.ts';
 import { logFatal, logWarning } from '$lib/states/toasts.svelte.ts';
 
 // This is an invariant, at least one trail must always exist
@@ -23,7 +22,6 @@ export const collapseTrailsContext = (): void => {
 
 export const stackTrail = (trail: Trail): void => {
 	trails = [...trails, trail];
-	newTrailStackedEventBus.emit();
 };
 
 export const shrinkTrails = (n: number): void => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -16,6 +16,14 @@ export const modifyLiteralWidth = (varCount: number): void => {
 	document.documentElement.style.setProperty('--assignment-width', widthKind);
 };
 
+export const modifyCRefWidth = (clauseCount: number): void => {
+	const basePixels: number = 25;
+	const valueToAdd: number = 5;
+	const clauseCountLength: number = String(clauseCount).slice().length
+	document.documentElement.style.setProperty('--cref-width', (basePixels + valueToAdd * clauseCountLength).toString() + 'px');
+};
+
+
 // Check to see if Chrome or Chromium is the current user's browser.
 export const testNavigatorAgent = (): boolean => {
 	return /chrom(e|ium)/.test(navigator.userAgent.toLowerCase());

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -18,11 +18,13 @@ export const modifyLiteralWidth = (varCount: number): void => {
 
 export const modifyCRefWidth = (clauseCount: number): void => {
 	const basePixels: number = 25;
-	const valueToAdd: number = 5;
-	const clauseCountLength: number = String(clauseCount).slice().length
-	document.documentElement.style.setProperty('--cref-width', (basePixels + valueToAdd * clauseCountLength).toString() + 'px');
+	const extraPixels: number = 5;
+	const clauseCountLength: number = String(clauseCount).slice().length;
+	document.documentElement.style.setProperty(
+		'--cref-width',
+		(basePixels + extraPixels * clauseCountLength).toString() + 'px'
+	);
 };
-
 
 // Check to see if Chrome or Chromium is the current user's browser.
 export const testNavigatorAgent = (): boolean => {


### PR DESCRIPTION
This pr aims to do some final tweaks to the application before the release of the 2-watch literals:

- Now the enum in the occurrence list components is adapted depending on the number of clauses that the problem has.
- There was a visual bug where the "revert up to here" button was not showing in childless decisions
- The "revert up to here" logic was not working on backtracking and dpll.
- A new statistic called "visited clauses" replaces the old "clauses left" statistic.
- Code cleaning.